### PR TITLE
Add fields that are related with substitute holiday

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ go:
   - "1.11"
   - "1.12"
   - "1.13"
+  - "1.14"
 
 before_install:
   - go get github.com/mattn/goveralls

--- a/custom_holiday_test.go
+++ b/custom_holiday_test.go
@@ -73,7 +73,7 @@ func TestCustomHoliday(t *testing.T) {
 		{11, 11, "Second Saturday", PublicHoliday},
 		{12, 9, "Second Saturday", PublicHoliday},
 	}
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }
 
 func TestNoFuncDefinition(t *testing.T) {

--- a/custom_holiday_test.go
+++ b/custom_holiday_test.go
@@ -1,21 +1,23 @@
-package flagday
+package flagday_test
 
 import (
 	"testing"
 	"time"
+
+	"github.com/pinzolo/flagday"
 )
 
-var custom DefType = 99
-var secondSaturday HolidayKind = 99
+var custom flagday.DefType = 99
+var secondSaturday flagday.HolidayKind = 99
 
 type customDef struct {
 	name    string
 	month   int
 	weekNum int
-	fn      func(def Definition, year int) Holiday
+	fn      func(def flagday.Definition, year int) flagday.Holiday
 }
 
-func (def customDef) Type() DefType {
+func (def customDef) Type() flagday.DefType {
 	return custom
 }
 
@@ -35,7 +37,7 @@ func (def customDef) WeekNum() int {
 	return def.weekNum
 }
 
-func (def customDef) Func() func(def Definition, year int) Holiday {
+func (def customDef) Func() func(def flagday.Definition, year int) flagday.Holiday {
 	return def.fn
 }
 
@@ -48,30 +50,30 @@ func (def customDef) End() int {
 }
 
 func TestCustomHoliday(t *testing.T) {
-	defs := make([]Definition, 12)
+	defs := make([]flagday.Definition, 12)
 	for i := 0; i <= 11; i++ {
 		def := customDef{
 			month:   i + 1,
 			weekNum: 2,
-			fn:      WeekNumHolidayFunc(time.Saturday),
+			fn:      flagday.WeekNumHolidayFunc(time.Saturday),
 		}
 		defs[i] = def
 	}
 	year := 2017
-	dates := Holidays(defs, year)
+	dates := flagday.Holidays(defs, year)
 	testdata := []expected{
-		{1, 14, "Second Saturday", PublicHoliday},
-		{2, 11, "Second Saturday", PublicHoliday},
-		{3, 11, "Second Saturday", PublicHoliday},
-		{4, 8, "Second Saturday", PublicHoliday},
-		{5, 13, "Second Saturday", PublicHoliday},
-		{6, 10, "Second Saturday", PublicHoliday},
-		{7, 8, "Second Saturday", PublicHoliday},
-		{8, 12, "Second Saturday", PublicHoliday},
-		{9, 9, "Second Saturday", PublicHoliday},
-		{10, 14, "Second Saturday", PublicHoliday},
-		{11, 11, "Second Saturday", PublicHoliday},
-		{12, 9, "Second Saturday", PublicHoliday},
+		{1, 14, "Second Saturday", flagday.PublicHoliday},
+		{2, 11, "Second Saturday", flagday.PublicHoliday},
+		{3, 11, "Second Saturday", flagday.PublicHoliday},
+		{4, 8, "Second Saturday", flagday.PublicHoliday},
+		{5, 13, "Second Saturday", flagday.PublicHoliday},
+		{6, 10, "Second Saturday", flagday.PublicHoliday},
+		{7, 8, "Second Saturday", flagday.PublicHoliday},
+		{8, 12, "Second Saturday", flagday.PublicHoliday},
+		{9, 9, "Second Saturday", flagday.PublicHoliday},
+		{10, 14, "Second Saturday", flagday.PublicHoliday},
+		{11, 11, "Second Saturday", flagday.PublicHoliday},
+		{12, 9, "Second Saturday", flagday.PublicHoliday},
 	}
 	testHolidays(t, year, dates, testdata)
 }
@@ -81,8 +83,8 @@ func TestNoFuncDefinition(t *testing.T) {
 		month:   1,
 		weekNum: 2,
 	}
-	defs := []Definition{def}
-	dates := Holidays(defs, 2017)
+	defs := []flagday.Definition{def}
+	dates := flagday.Holidays(defs, 2017)
 	if len(dates) != 0 {
 		t.Error("should return date when given no func definition")
 	}

--- a/equinox_day_test.go
+++ b/equinox_day_test.go
@@ -1,6 +1,10 @@
-package flagday
+package flagday_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/pinzolo/flagday"
+)
 
 type equinoxDay struct {
 	year int
@@ -321,7 +325,7 @@ var autumnEquinoxDays = []equinoxDay{
 
 func TestSpringEquinoxDay(t *testing.T) {
 	for _, ed := range springEquinoxDays {
-		d, err := PublicHolidayOf(ed.year, 3, ed.day)
+		d, err := flagday.PublicHolidayOf(ed.year, 3, ed.day)
 		if err != nil {
 			t.Errorf("spring equinox day in %d expects %d, but got %d", ed.year, ed.day, d.Day())
 		}
@@ -330,7 +334,7 @@ func TestSpringEquinoxDay(t *testing.T) {
 
 func TestAutumnEquinoxDay(t *testing.T) {
 	for _, ed := range autumnEquinoxDays {
-		d, err := PublicHolidayOf(ed.year, 9, ed.day)
+		d, err := flagday.PublicHolidayOf(ed.year, 9, ed.day)
 		if err != nil {
 			t.Errorf("autumn equinox day in %d expects %d, but got %d", ed.year, ed.day, d.Day())
 		}

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,4 @@
+package flagday
+
+var TimeFrom = timeFrom
+var CacheRef = &cache

--- a/flagday.go
+++ b/flagday.go
@@ -143,5 +143,5 @@ func substituteHolidayOf(holiday Holiday) (Holiday, error) {
 	if holiday.Month() == 5 && (holiday.Day() == 3 || holiday.Day() == 4) {
 		day = 6
 	}
-	return newSubstituteHoliday(holiday.Year(), holiday.Month(), day), nil
+	return newSubstituteHoliday(holiday.Year(), holiday.Month(), day, holiday), nil
 }

--- a/flagday.go
+++ b/flagday.go
@@ -60,6 +60,9 @@ func Holidays(defs []Definition, year int) []Holiday {
 		// Substitute holiday
 		substDate, err := substituteHolidayOf(holiday)
 		if err == nil {
+			if ss, ok := holiday.(substitutedSetter); ok {
+				ss.SetSubstituted(true)
+			}
 			holidays = append(holidays, substDate)
 		}
 	}

--- a/flagday_test.go
+++ b/flagday_test.go
@@ -33,7 +33,7 @@ func BenchmarkInYearWithoutCache(b *testing.B) {
 	}
 }
 
-func check(t *testing.T, year int, dates []Holiday, testdata []expected) {
+func testHolidays(t *testing.T, year int, dates []Holiday, testdata []expected) {
 	t.Helper()
 	if len(testdata) != len(dates) {
 		t.Errorf("holiday count is not match, expected %d but got %d", len(testdata), len(dates))
@@ -41,11 +41,11 @@ func check(t *testing.T, year int, dates []Holiday, testdata []expected) {
 	}
 	for i, td := range testdata {
 		date := dates[i]
-		checkDate(t, year, date, td)
+		testDate(t, year, date, td)
 	}
 }
 
-func checkDate(t *testing.T, year int, date Holiday, td expected) {
+func testDate(t *testing.T, year int, date Holiday, td expected) {
 	t.Helper()
 	s := date.Time().Format("2006/1/2")
 	if date.Year() != year {
@@ -87,7 +87,7 @@ func TestInYear(t *testing.T) {
 	}
 	year := 2017
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }
 
 func TestIn2018(t *testing.T) {
@@ -115,7 +115,7 @@ func TestIn2018(t *testing.T) {
 	}
 	year := 2018
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }
 
 func TestIn2019(t *testing.T) {
@@ -145,7 +145,7 @@ func TestIn2019(t *testing.T) {
 	}
 	year := 2019
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }
 
 func TestIn2020(t *testing.T) {
@@ -171,7 +171,7 @@ func TestIn2020(t *testing.T) {
 	}
 	year := 2020
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }
 
 func TestIn2021(t *testing.T) {
@@ -195,7 +195,7 @@ func TestIn2021(t *testing.T) {
 	}
 	year := 2021
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }
 
 func TestInMonth(t *testing.T) {
@@ -206,7 +206,7 @@ func TestInMonth(t *testing.T) {
 	}
 	year := 2017
 	dates := InMonth(year, 1)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 
 	dates = InMonth(year, 6)
 	if len(dates) != 0 {
@@ -219,7 +219,7 @@ func TestPublicHolidayOf(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	checkDate(t, 2017, d, expected{11, 23, "勤労感謝の日", PublicHoliday})
+	testDate(t, 2017, d, expected{11, 23, "勤労感謝の日", PublicHoliday})
 	_, err = PublicHolidayOf(2017, 11, 24)
 	if err == nil {
 		t.Errorf("2017/11/24 is not public holiday, PublicHolidayOf should return error")
@@ -240,7 +240,7 @@ func TestPublicHolidayTimeOf(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	checkDate(t, 2017, d, expected{11, 23, "勤労感謝の日", PublicHoliday})
+	testDate(t, 2017, d, expected{11, 23, "勤労感謝の日", PublicHoliday})
 	_, err = PublicHolidayTimeOf(timeFrom(2017, 11, 24))
 	if err == nil {
 		t.Errorf("2017/11/24 is not public holiday, PublicHolidayOf should return error")

--- a/flagday_test.go
+++ b/flagday_test.go
@@ -1,23 +1,25 @@
-package flagday
+package flagday_test
 
 import (
 	"testing"
+
+	"github.com/pinzolo/flagday"
 )
 
 type expected struct {
 	month int
 	day   int
 	name  string
-	kind  HolidayKind
+	kind  flagday.HolidayKind
 }
 
 func BenchmarkInYear(b *testing.B) {
 	begin := 1948
 	end := 2017
-	ClearCache()
+	flagday.ClearCache()
 	for i := 0; i < b.N; i++ {
 		for j := begin; j <= end; j++ {
-			InYear(j)
+			flagday.InYear(j)
 		}
 	}
 }
@@ -26,14 +28,14 @@ func BenchmarkInYearWithoutCache(b *testing.B) {
 	begin := 1948
 	end := 2017
 	for i := 0; i < b.N; i++ {
-		ClearCache()
+		flagday.ClearCache()
 		for j := begin; j <= end; j++ {
-			InYear(j)
+			flagday.InYear(j)
 		}
 	}
 }
 
-func testHolidays(t *testing.T, year int, dates []Holiday, testdata []expected) {
+func testHolidays(t *testing.T, year int, dates []flagday.Holiday, testdata []expected) {
 	t.Helper()
 	if len(testdata) != len(dates) {
 		t.Errorf("holiday count is not match, expected %d but got %d", len(testdata), len(dates))
@@ -45,7 +47,7 @@ func testHolidays(t *testing.T, year int, dates []Holiday, testdata []expected) 
 	}
 }
 
-func testDate(t *testing.T, year int, date Holiday, td expected) {
+func testDate(t *testing.T, year int, date flagday.Holiday, td expected) {
 	t.Helper()
 	s := date.Time().Format("2006/1/2")
 	if date.Year() != year {
@@ -67,207 +69,207 @@ func testDate(t *testing.T, year int, date Holiday, td expected) {
 
 func TestInYear(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 2, "振替休日", SubstituteHoliday},
-		{1, 9, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 20, "春分の日", PublicHoliday},
-		{4, 29, "昭和の日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "みどりの日", PublicHoliday},
-		{5, 5, "こどもの日", PublicHoliday},
-		{7, 17, "海の日", PublicHoliday},
-		{8, 11, "山の日", PublicHoliday},
-		{9, 18, "敬老の日", PublicHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 9, "体育の日", PublicHoliday},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
-		{12, 23, "天皇誕生日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 2, "振替休日", flagday.SubstituteHoliday},
+		{1, 9, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 20, "春分の日", flagday.PublicHoliday},
+		{4, 29, "昭和の日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "みどりの日", flagday.PublicHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{7, 17, "海の日", flagday.PublicHoliday},
+		{8, 11, "山の日", flagday.PublicHoliday},
+		{9, 18, "敬老の日", flagday.PublicHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 9, "体育の日", flagday.PublicHoliday},
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
+		{12, 23, "天皇誕生日", flagday.PublicHoliday},
 	}
 	year := 2017
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 }
 
 func TestIn2018(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 8, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{2, 12, "振替休日", SubstituteHoliday},
-		{3, 21, "春分の日", PublicHoliday},
-		{4, 29, "昭和の日", PublicHoliday},
-		{4, 30, "振替休日", SubstituteHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "みどりの日", PublicHoliday},
-		{5, 5, "こどもの日", PublicHoliday},
-		{7, 16, "海の日", PublicHoliday},
-		{8, 11, "山の日", PublicHoliday},
-		{9, 17, "敬老の日", PublicHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{9, 24, "振替休日", SubstituteHoliday},
-		{10, 8, "体育の日", PublicHoliday},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
-		{12, 23, "天皇誕生日", PublicHoliday},
-		{12, 24, "振替休日", SubstituteHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 8, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{2, 12, "振替休日", flagday.SubstituteHoliday},
+		{3, 21, "春分の日", flagday.PublicHoliday},
+		{4, 29, "昭和の日", flagday.PublicHoliday},
+		{4, 30, "振替休日", flagday.SubstituteHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "みどりの日", flagday.PublicHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{7, 16, "海の日", flagday.PublicHoliday},
+		{8, 11, "山の日", flagday.PublicHoliday},
+		{9, 17, "敬老の日", flagday.PublicHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{9, 24, "振替休日", flagday.SubstituteHoliday},
+		{10, 8, "体育の日", flagday.PublicHoliday},
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
+		{12, 23, "天皇誕生日", flagday.PublicHoliday},
+		{12, 24, "振替休日", flagday.SubstituteHoliday},
 	}
 	year := 2018
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 }
 
 func TestIn2019(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 14, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 21, "春分の日", PublicHoliday},
-		{4, 29, "昭和の日", PublicHoliday},
-		{4, 30, "国民の休日", NationalHoliday},
-		{5, 1, "即位の礼", ImperialRelated},
-		{5, 2, "国民の休日", NationalHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "みどりの日", PublicHoliday},
-		{5, 5, "こどもの日", PublicHoliday},
-		{5, 6, "振替休日", SubstituteHoliday},
-		{7, 15, "海の日", PublicHoliday},
-		{8, 11, "山の日", PublicHoliday},
-		{8, 12, "振替休日", SubstituteHoliday},
-		{9, 16, "敬老の日", PublicHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 14, "体育の日", PublicHoliday},
-		{10, 22, "即位礼正殿の儀", ImperialRelated},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 4, "振替休日", SubstituteHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 14, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 21, "春分の日", flagday.PublicHoliday},
+		{4, 29, "昭和の日", flagday.PublicHoliday},
+		{4, 30, "国民の休日", flagday.NationalHoliday},
+		{5, 1, "即位の礼", flagday.ImperialRelated},
+		{5, 2, "国民の休日", flagday.NationalHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "みどりの日", flagday.PublicHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{5, 6, "振替休日", flagday.SubstituteHoliday},
+		{7, 15, "海の日", flagday.PublicHoliday},
+		{8, 11, "山の日", flagday.PublicHoliday},
+		{8, 12, "振替休日", flagday.SubstituteHoliday},
+		{9, 16, "敬老の日", flagday.PublicHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 14, "体育の日", flagday.PublicHoliday},
+		{10, 22, "即位礼正殿の儀", flagday.ImperialRelated},
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 4, "振替休日", flagday.SubstituteHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
 	}
 	year := 2019
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 }
 
 func TestIn2020(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 13, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{2, 23, "天皇誕生日", PublicHoliday},
-		{2, 24, "振替休日", SubstituteHoliday},
-		{3, 20, "春分の日", PublicHoliday},
-		{4, 29, "昭和の日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "みどりの日", PublicHoliday},
-		{5, 5, "こどもの日", PublicHoliday},
-		{5, 6, "振替休日", SubstituteHoliday},
-		{7, 23, "海の日", PublicHoliday},
-		{7, 24, "スポーツの日", PublicHoliday},
-		{8, 10, "山の日", PublicHoliday},
-		{9, 21, "敬老の日", PublicHoliday},
-		{9, 22, "秋分の日", PublicHoliday},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 13, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{2, 23, "天皇誕生日", flagday.PublicHoliday},
+		{2, 24, "振替休日", flagday.SubstituteHoliday},
+		{3, 20, "春分の日", flagday.PublicHoliday},
+		{4, 29, "昭和の日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "みどりの日", flagday.PublicHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{5, 6, "振替休日", flagday.SubstituteHoliday},
+		{7, 23, "海の日", flagday.PublicHoliday},
+		{7, 24, "スポーツの日", flagday.PublicHoliday},
+		{8, 10, "山の日", flagday.PublicHoliday},
+		{9, 21, "敬老の日", flagday.PublicHoliday},
+		{9, 22, "秋分の日", flagday.PublicHoliday},
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
 	}
 	year := 2020
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 }
 
 func TestIn2021(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 11, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{2, 23, "天皇誕生日", PublicHoliday},
-		{3, 20, "春分の日", PublicHoliday},
-		{4, 29, "昭和の日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "みどりの日", PublicHoliday},
-		{5, 5, "こどもの日", PublicHoliday},
-		{7, 19, "海の日", PublicHoliday},
-		{8, 11, "山の日", PublicHoliday},
-		{9, 20, "敬老の日", PublicHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 11, "スポーツの日", PublicHoliday},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 11, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{2, 23, "天皇誕生日", flagday.PublicHoliday},
+		{3, 20, "春分の日", flagday.PublicHoliday},
+		{4, 29, "昭和の日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "みどりの日", flagday.PublicHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{7, 19, "海の日", flagday.PublicHoliday},
+		{8, 11, "山の日", flagday.PublicHoliday},
+		{9, 20, "敬老の日", flagday.PublicHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 11, "スポーツの日", flagday.PublicHoliday},
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
 	}
 	year := 2021
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 }
 
 func TestInMonth(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 2, "振替休日", SubstituteHoliday},
-		{1, 9, "成人の日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 2, "振替休日", flagday.SubstituteHoliday},
+		{1, 9, "成人の日", flagday.PublicHoliday},
 	}
 	year := 2017
-	dates := InMonth(year, 1)
+	dates := flagday.InMonth(year, 1)
 	testHolidays(t, year, dates, testdata)
 
-	dates = InMonth(year, 6)
+	dates = flagday.InMonth(year, 6)
 	if len(dates) != 0 {
 		t.Error("should return empty slice")
 	}
 }
 
 func TestPublicHolidayOf(t *testing.T) {
-	d, err := PublicHolidayOf(2017, 11, 23)
+	d, err := flagday.PublicHolidayOf(2017, 11, 23)
 	if err != nil {
 		t.Error(err)
 	}
-	testDate(t, 2017, d, expected{11, 23, "勤労感謝の日", PublicHoliday})
-	_, err = PublicHolidayOf(2017, 11, 24)
+	testDate(t, 2017, d, expected{11, 23, "勤労感謝の日", flagday.PublicHoliday})
+	_, err = flagday.PublicHolidayOf(2017, 11, 24)
 	if err == nil {
 		t.Errorf("2017/11/24 is not public holiday, PublicHolidayOf should return error")
 	}
 }
 
 func TestIsPublicHoliday(t *testing.T) {
-	if !IsPublicHoliday(2017, 11, 23) {
+	if !flagday.IsPublicHoliday(2017, 11, 23) {
 		t.Errorf("2017/11/23 is public holiday, but IsPublicHoliday returns false")
 	}
-	if IsPublicHoliday(2017, 11, 24) {
+	if flagday.IsPublicHoliday(2017, 11, 24) {
 		t.Errorf("2017/11/24 is public holiday, but IsPublicHoliday returns true")
 	}
 }
 
 func TestPublicHolidayTimeOf(t *testing.T) {
-	d, err := PublicHolidayTimeOf(timeFrom(2017, 11, 23))
+	d, err := flagday.PublicHolidayTimeOf(flagday.TimeFrom(2017, 11, 23))
 	if err != nil {
 		t.Error(err)
 	}
-	testDate(t, 2017, d, expected{11, 23, "勤労感謝の日", PublicHoliday})
-	_, err = PublicHolidayTimeOf(timeFrom(2017, 11, 24))
+	testDate(t, 2017, d, expected{11, 23, "勤労感謝の日", flagday.PublicHoliday})
+	_, err = flagday.PublicHolidayTimeOf(flagday.TimeFrom(2017, 11, 24))
 	if err == nil {
 		t.Errorf("2017/11/24 is not public holiday, PublicHolidayOf should return error")
 	}
 }
 
 func TestIsPublicHolidayTime(t *testing.T) {
-	if !IsPublicHolidayTime(timeFrom(2017, 11, 23)) {
+	if !flagday.IsPublicHolidayTime(flagday.TimeFrom(2017, 11, 23)) {
 		t.Errorf("2017/11/23 is public holiday, but IsPublicHoliday returns false")
 	}
-	if IsPublicHolidayTime(timeFrom(2017, 11, 24)) {
+	if flagday.IsPublicHolidayTime(flagday.TimeFrom(2017, 11, 24)) {
 		t.Errorf("2017/11/24 is public holiday, but IsPublicHoliday returns true")
 	}
 }
 
 func TestClearCache(t *testing.T) {
-	InYear(2017)
-	if len(cache) == 0 {
+	flagday.InYear(2017)
+	if len(*flagday.CacheRef) == 0 {
 		t.Error("cache length should be zero")
 	}
-	ClearCache()
-	if len(cache) != 0 {
+	flagday.ClearCache()
+	if len(*flagday.CacheRef) != 0 {
 		t.Error("cache length should be zero after ClearCache called")
 	}
 }
 
-func logDates(t *testing.T, dates []Holiday) {
+func logDates(t *testing.T, dates []flagday.Holiday) {
 	for _, d := range dates {
 		t.Logf("%s %s", d.Time().Format("2006/01/02"), d.Name())
 	}

--- a/happy_monday_test.go
+++ b/happy_monday_test.go
@@ -24,7 +24,7 @@ func TestHappyMondayBefore(t *testing.T) {
 	}
 	year := 1999
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }
 
 func TestHappyMonday1st(t *testing.T) {
@@ -47,7 +47,7 @@ func TestHappyMonday1st(t *testing.T) {
 	}
 	year := 2000
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }
 
 func TestHappyMonday2nd(t *testing.T) {
@@ -71,7 +71,7 @@ func TestHappyMonday2nd(t *testing.T) {
 	}
 	year := 2003
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 
 	testdata = []expected{
 		{1, 1, "元日", PublicHoliday},
@@ -92,5 +92,5 @@ func TestHappyMonday2nd(t *testing.T) {
 	}
 	year = 2004
 	dates = InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }

--- a/happy_monday_test.go
+++ b/happy_monday_test.go
@@ -1,96 +1,100 @@
-package flagday
+package flagday_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/pinzolo/flagday"
+)
 
 func TestHappyMondayBefore(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 15, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 21, "春分の日", PublicHoliday},
-		{3, 22, "振替休日", SubstituteHoliday},
-		{4, 29, "みどりの日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "国民の休日", NationalHoliday},
-		{5, 5, "こどもの日", PublicHoliday},
-		{7, 20, "海の日", PublicHoliday},
-		{9, 15, "敬老の日", PublicHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 10, "体育の日", PublicHoliday},
-		{10, 11, "振替休日", SubstituteHoliday},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
-		{12, 23, "天皇誕生日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 15, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 21, "春分の日", flagday.PublicHoliday},
+		{3, 22, "振替休日", flagday.SubstituteHoliday},
+		{4, 29, "みどりの日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "国民の休日", flagday.NationalHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{7, 20, "海の日", flagday.PublicHoliday},
+		{9, 15, "敬老の日", flagday.PublicHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 10, "体育の日", flagday.PublicHoliday},
+		{10, 11, "振替休日", flagday.SubstituteHoliday},
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
+		{12, 23, "天皇誕生日", flagday.PublicHoliday},
 	}
 	year := 1999
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 }
 
 func TestHappyMonday1st(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 10, "成人の日", PublicHoliday}, // changed
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 20, "春分の日", PublicHoliday},
-		{4, 29, "みどりの日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "国民の休日", NationalHoliday},
-		{5, 5, "こどもの日", PublicHoliday},
-		{7, 20, "海の日", PublicHoliday},
-		{9, 15, "敬老の日", PublicHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 9, "体育の日", PublicHoliday}, // changed
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
-		{12, 23, "天皇誕生日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 10, "成人の日", flagday.PublicHoliday}, // changed
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 20, "春分の日", flagday.PublicHoliday},
+		{4, 29, "みどりの日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "国民の休日", flagday.NationalHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{7, 20, "海の日", flagday.PublicHoliday},
+		{9, 15, "敬老の日", flagday.PublicHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 9, "体育の日", flagday.PublicHoliday}, // changed
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
+		{12, 23, "天皇誕生日", flagday.PublicHoliday},
 	}
 	year := 2000
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 }
 
 func TestHappyMonday2nd(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 13, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 21, "春分の日", PublicHoliday},
-		{4, 29, "みどりの日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "国民の休日", NationalHoliday},
-		{5, 5, "こどもの日", PublicHoliday},
-		{7, 21, "海の日", PublicHoliday}, // changed
-		{9, 15, "敬老の日", PublicHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 13, "体育の日", PublicHoliday},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
-		{11, 24, "振替休日", SubstituteHoliday},
-		{12, 23, "天皇誕生日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 13, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 21, "春分の日", flagday.PublicHoliday},
+		{4, 29, "みどりの日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "国民の休日", flagday.NationalHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{7, 21, "海の日", flagday.PublicHoliday}, // changed
+		{9, 15, "敬老の日", flagday.PublicHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 13, "体育の日", flagday.PublicHoliday},
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
+		{11, 24, "振替休日", flagday.SubstituteHoliday},
+		{12, 23, "天皇誕生日", flagday.PublicHoliday},
 	}
 	year := 2003
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 
 	testdata = []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 12, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 20, "春分の日", PublicHoliday},
-		{4, 29, "みどりの日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "国民の休日", NationalHoliday},
-		{5, 5, "こどもの日", PublicHoliday},
-		{7, 19, "海の日", PublicHoliday},
-		{9, 20, "敬老の日", PublicHoliday}, // changed
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 11, "体育の日", PublicHoliday},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
-		{12, 23, "天皇誕生日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 12, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 20, "春分の日", flagday.PublicHoliday},
+		{4, 29, "みどりの日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "国民の休日", flagday.NationalHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{7, 19, "海の日", flagday.PublicHoliday},
+		{9, 20, "敬老の日", flagday.PublicHoliday}, // changed
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 11, "体育の日", flagday.PublicHoliday},
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
+		{12, 23, "天皇誕生日", flagday.PublicHoliday},
 	}
 	year = 2004
-	dates = InYear(year)
+	dates = flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 }

--- a/holiday.go
+++ b/holiday.go
@@ -40,16 +40,20 @@ type Holiday interface {
 	Kind() HolidayKind
 	// Time is time.Time instance of holiday (JST)
 	Time() time.Time
+	// Original is original holiday.
+	// This field is only set when holiday is substitute.
+	Original() Holiday
 }
 
 type holiday struct {
-	def   *Definition
-	year  int
-	month int
-	day   int
-	name  string
-	kind  HolidayKind
-	time  time.Time
+	def      *Definition
+	year     int
+	month    int
+	day      int
+	name     string
+	kind     HolidayKind
+	time     time.Time
+	original Holiday
 }
 
 func (d holiday) Def() *Definition {
@@ -80,33 +84,38 @@ func (d holiday) Time() time.Time {
 	return d.time
 }
 
+func (d holiday) Original() Holiday {
+	return d.original
+}
+
 // NewHoliday returns new date with time.
-func NewHoliday(def *Definition, year, month, day int, name string, kind HolidayKind) Holiday {
-	return holiday{
-		def:   def,
-		year:  year,
-		month: month,
-		day:   day,
-		name:  name,
-		kind:  kind,
-		time:  timeFrom(year, month, day),
+func NewHoliday(def *Definition, year, month, day int, name string, kind HolidayKind, original Holiday) Holiday {
+	return &holiday{
+		def:      def,
+		year:     year,
+		month:    month,
+		day:      day,
+		name:     name,
+		kind:     kind,
+		time:     timeFrom(year, month, day),
+		original: original,
 	}
 }
 
 func newPublicHoliday(def Definition, year, day int) Holiday {
-	return NewHoliday(&def, year, def.Month(), day, def.Name(), PublicHoliday)
+	return NewHoliday(&def, year, def.Month(), day, def.Name(), PublicHoliday, nil)
 }
 
 func newNationalHoliday(year, month, day int) Holiday {
-	return NewHoliday(nil, year, month, day, "国民の休日", NationalHoliday)
+	return NewHoliday(nil, year, month, day, "国民の休日", NationalHoliday, nil)
 }
 
-func newSubstituteHoliday(year, month, day int) Holiday {
-	return NewHoliday(nil, year, month, day, "振替休日", SubstituteHoliday)
+func newSubstituteHoliday(year, month, day int, original Holiday) Holiday {
+	return NewHoliday(nil, year, month, day, "振替休日", SubstituteHoliday, original)
 }
 
 func newImperialRelatedHoliday(def Definition, year, day int) Holiday {
-	return NewHoliday(&def, year, def.Month(), day, def.Name(), ImperialRelated)
+	return NewHoliday(&def, year, def.Month(), day, def.Name(), ImperialRelated, nil)
 }
 
 func jst() *time.Location {

--- a/holiday.go
+++ b/holiday.go
@@ -47,6 +47,10 @@ type Holiday interface {
 	IsSubstituted() bool
 }
 
+type substitutedSetter interface {
+	SetSubstituted(b bool)
+}
+
 type holiday struct {
 	def         *Definition
 	year        int
@@ -59,45 +63,49 @@ type holiday struct {
 	substituted bool
 }
 
-func (d holiday) Def() *Definition {
+func (d *holiday) Def() *Definition {
 	return d.def
 }
 
-func (d holiday) Year() int {
+func (d *holiday) Year() int {
 	return d.year
 }
 
-func (d holiday) Month() int {
+func (d *holiday) Month() int {
 	return d.month
 }
 
-func (d holiday) Day() int {
+func (d *holiday) Day() int {
 	return d.day
 }
 
-func (d holiday) Name() string {
+func (d *holiday) Name() string {
 	return d.name
 }
 
-func (d holiday) Kind() HolidayKind {
+func (d *holiday) Kind() HolidayKind {
 	return d.kind
 }
 
-func (d holiday) Time() time.Time {
+func (d *holiday) Time() time.Time {
 	return d.time
 }
 
-func (d holiday) Original() Holiday {
+func (d *holiday) Original() Holiday {
 	return d.original
 }
 
-func (d holiday) IsSubstituted() bool {
+func (d *holiday) IsSubstituted() bool {
 	return d.substituted
+}
+
+func (d *holiday) SetSubstituted(b bool) {
+	d.substituted = b
 }
 
 // NewHoliday returns new date with time.
 func NewHoliday(def *Definition, year, month, day int, name string, kind HolidayKind, original Holiday) Holiday {
-	return holiday{
+	return &holiday{
 		def:      def,
 		year:     year,
 		month:    month,

--- a/holiday.go
+++ b/holiday.go
@@ -41,19 +41,22 @@ type Holiday interface {
 	// Time is time.Time instance of holiday (JST)
 	Time() time.Time
 	// Original is original holiday.
-	// This field is only set when holiday is substitute.
+	// This field is only set when holiday is substitute holiday.
 	Original() Holiday
+	// IsSubstituted returns that this holiday is substituted by substitute holiday.
+	IsSubstituted() bool
 }
 
 type holiday struct {
-	def      *Definition
-	year     int
-	month    int
-	day      int
-	name     string
-	kind     HolidayKind
-	time     time.Time
-	original Holiday
+	def         *Definition
+	year        int
+	month       int
+	day         int
+	name        string
+	kind        HolidayKind
+	time        time.Time
+	original    Holiday
+	substituted bool
 }
 
 func (d holiday) Def() *Definition {
@@ -88,9 +91,13 @@ func (d holiday) Original() Holiday {
 	return d.original
 }
 
+func (d holiday) IsSubstituted() bool {
+	return d.substituted
+}
+
 // NewHoliday returns new date with time.
 func NewHoliday(def *Definition, year, month, day int, name string, kind HolidayKind, original Holiday) Holiday {
-	return &holiday{
+	return holiday{
 		def:      def,
 		year:     year,
 		month:    month,

--- a/holiday_test.go
+++ b/holiday_test.go
@@ -1,8 +1,10 @@
-package flagday
+package flagday_test
 
 import (
 	"fmt"
 	"testing"
+
+	"github.com/pinzolo/flagday"
 )
 
 func TestTime(t *testing.T) {
@@ -10,7 +12,7 @@ func TestTime(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	d := FixedDateHoliday(def, 2017)
+	d := flagday.FixedDateHoliday(def, 2017)
 	tm := d.Time()
 	if d.Def() == nil {
 		t.Error("holiday should have own definition on public holiday")
@@ -41,8 +43,8 @@ func TestTime(t *testing.T) {
 	}
 }
 
-func getDef(name string, year int) (Definition, error) {
-	for _, def := range DefsInYear(year) {
+func getDef(name string, year int) (flagday.Definition, error) {
+	for _, def := range flagday.DefsInYear(year) {
 		if def.Name() == name {
 			return def, nil
 		}
@@ -50,7 +52,7 @@ func getDef(name string, year int) (Definition, error) {
 	return nil, fmt.Errorf("definition not found: %s", name)
 }
 
-func isSameDef(def1 Definition, def2 Definition) bool {
+func isSameDef(def1 flagday.Definition, def2 flagday.Definition) bool {
 	if def1.Type() != def2.Type() {
 		return false
 	}

--- a/holiday_test.go
+++ b/holiday_test.go
@@ -3,6 +3,7 @@ package flagday_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/pinzolo/flagday"
 )
@@ -20,6 +21,11 @@ func TestTime(t *testing.T) {
 	if !isSameDef(*d.Def(), def) {
 		t.Error("holiday should have same definition")
 	}
+	testTimeFields(t, tm, d)
+}
+
+func testTimeFields(t *testing.T, tm time.Time, d flagday.Holiday) {
+	t.Helper()
 	if tm.Year() != d.Year() {
 		t.Errorf("converted time should have %d as year, but got %d", d.Year(), tm.Year())
 	}

--- a/imperial_related_holiday_test.go
+++ b/imperial_related_holiday_test.go
@@ -1,86 +1,90 @@
-package flagday
+package flagday_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/pinzolo/flagday"
+)
 
 func TestWeddingOfPrinceAkihito(t *testing.T) {
-	_, err := PublicHolidayOf(1958, 4, 10)
+	_, err := flagday.PublicHolidayOf(1958, 4, 10)
 	if err == nil {
 		t.Errorf("1958/04/10 is not holiday")
 	}
-	d, err := PublicHolidayOf(1959, 4, 10)
+	d, err := flagday.PublicHolidayOf(1959, 4, 10)
 	if err != nil {
 		t.Errorf("1959/04/10 is not holiday")
 	}
 	if d.Name() != "皇太子明仁親王の結婚の儀" {
 		t.Errorf("invalid holiday name, got %s", d.Name())
 	}
-	if d.Kind() != ImperialRelated {
-		t.Errorf("kind mismatch, expected %v but got %v", ImperialRelated, d.Kind())
+	if d.Kind() != flagday.ImperialRelated {
+		t.Errorf("kind mismatch, expected %v but got %v", flagday.ImperialRelated, d.Kind())
 	}
-	_, err = PublicHolidayOf(1960, 4, 10)
+	_, err = flagday.PublicHolidayOf(1960, 4, 10)
 	if err == nil {
 		t.Errorf("1960/04/10 is not holiday")
 	}
 }
 
 func TestFuneralCeremonyOfEmperorShowa(t *testing.T) {
-	_, err := PublicHolidayOf(1988, 2, 24)
+	_, err := flagday.PublicHolidayOf(1988, 2, 24)
 	if err == nil {
 		t.Errorf("1988/02/24 is not holiday")
 	}
-	d, err := PublicHolidayOf(1989, 2, 24)
+	d, err := flagday.PublicHolidayOf(1989, 2, 24)
 	if err != nil {
 		t.Errorf("1989/02/24 is not holiday")
 	}
 	if d.Name() != "昭和天皇の大喪の礼" {
 		t.Errorf("invalid holiday name, got %s", d.Name())
 	}
-	if d.Kind() != ImperialRelated {
-		t.Errorf("kind mismatch, expected %v but got %v", ImperialRelated, d.Kind())
+	if d.Kind() != flagday.ImperialRelated {
+		t.Errorf("kind mismatch, expected %v but got %v", flagday.ImperialRelated, d.Kind())
 	}
-	_, err = PublicHolidayOf(1990, 2, 24)
+	_, err = flagday.PublicHolidayOf(1990, 2, 24)
 	if err == nil {
 		t.Errorf("1990/02/24 is not holiday")
 	}
 }
 
 func TestCeremonyOfSokuiReiseiden(t *testing.T) {
-	_, err := PublicHolidayOf(1989, 11, 12)
+	_, err := flagday.PublicHolidayOf(1989, 11, 12)
 	if err == nil {
 		t.Errorf("1988/02/24 is not holiday")
 	}
-	d, err := PublicHolidayOf(1990, 11, 12)
+	d, err := flagday.PublicHolidayOf(1990, 11, 12)
 	if err != nil {
 		t.Errorf("1989/02/24 is not holiday")
 	}
 	if d.Name() != "即位礼正殿の儀" {
 		t.Errorf("invalid holiday name, got %s", d.Name())
 	}
-	if d.Kind() != ImperialRelated {
-		t.Errorf("kind mismatch, expected %v but got %v", ImperialRelated, d.Kind())
+	if d.Kind() != flagday.ImperialRelated {
+		t.Errorf("kind mismatch, expected %v but got %v", flagday.ImperialRelated, d.Kind())
 	}
-	_, err = PublicHolidayOf(1991, 11, 12)
+	_, err = flagday.PublicHolidayOf(1991, 11, 12)
 	if err == nil {
 		t.Errorf("1990/02/24 is not holiday")
 	}
 }
 
 func TestWeddingOfPrinceNaruhito(t *testing.T) {
-	_, err := PublicHolidayOf(1992, 6, 9)
+	_, err := flagday.PublicHolidayOf(1992, 6, 9)
 	if err == nil {
 		t.Errorf("1992/06/09 is not holiday")
 	}
-	d, err := PublicHolidayOf(1993, 6, 9)
+	d, err := flagday.PublicHolidayOf(1993, 6, 9)
 	if err != nil {
 		t.Errorf("1993/06/09 is not holiday")
 	}
 	if d.Name() != "皇太子徳仁親王の結婚の儀" {
 		t.Errorf("invalid holiday name, got %s", d.Name())
 	}
-	if d.Kind() != ImperialRelated {
-		t.Errorf("kind mismatch, expected %v but got %v", ImperialRelated, d.Kind())
+	if d.Kind() != flagday.ImperialRelated {
+		t.Errorf("kind mismatch, expected %v but got %v", flagday.ImperialRelated, d.Kind())
 	}
-	_, err = PublicHolidayOf(1994, 6, 9)
+	_, err = flagday.PublicHolidayOf(1994, 6, 9)
 	if err == nil {
 		t.Errorf("1994/06/09 is not holiday")
 	}

--- a/national_holiday_test.go
+++ b/national_holiday_test.go
@@ -1,51 +1,55 @@
-package flagday
+package flagday_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/pinzolo/flagday"
+)
 
 func TestNationalHoliday(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 12, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 21, "春分の日", PublicHoliday},
-		{4, 29, "昭和の日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "みどりの日", PublicHoliday},
-		{5, 5, "こどもの日", PublicHoliday},
-		{5, 6, "振替休日", SubstituteHoliday},
-		{7, 20, "海の日", PublicHoliday},
-		{9, 21, "敬老の日", PublicHoliday},
-		{9, 22, "国民の休日", NationalHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 12, "体育の日", PublicHoliday},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
-		{12, 23, "天皇誕生日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 12, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 21, "春分の日", flagday.PublicHoliday},
+		{4, 29, "昭和の日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "みどりの日", flagday.PublicHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{5, 6, "振替休日", flagday.SubstituteHoliday},
+		{7, 20, "海の日", flagday.PublicHoliday},
+		{9, 21, "敬老の日", flagday.PublicHoliday},
+		{9, 22, "国民の休日", flagday.NationalHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 12, "体育の日", flagday.PublicHoliday},
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
+		{12, 23, "天皇誕生日", flagday.PublicHoliday},
 	}
 	year := 2015
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 }
 
 func TestNationalHolidayBefore(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 15, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 21, "春分の日", PublicHoliday},
-		{3, 22, "振替休日", SubstituteHoliday},
-		{4, 29, "天皇誕生日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 15, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 21, "春分の日", flagday.PublicHoliday},
+		{3, 22, "振替休日", flagday.SubstituteHoliday},
+		{4, 29, "天皇誕生日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
 		// 5/4 is not holiday
-		{5, 5, "こどもの日", PublicHoliday},
-		{9, 15, "敬老の日", PublicHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 10, "体育の日", PublicHoliday},
-		{10, 11, "振替休日", SubstituteHoliday},
-		{11, 03, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{9, 15, "敬老の日", flagday.PublicHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 10, "体育の日", flagday.PublicHoliday},
+		{10, 11, "振替休日", flagday.SubstituteHoliday},
+		{11, 03, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
 	}
 	year := 1982
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 }

--- a/national_holiday_test.go
+++ b/national_holiday_test.go
@@ -24,7 +24,7 @@ func TestNationalHoliday(t *testing.T) {
 	}
 	year := 2015
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }
 
 func TestNationalHolidayBefore(t *testing.T) {
@@ -47,5 +47,5 @@ func TestNationalHolidayBefore(t *testing.T) {
 	}
 	year := 1982
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }

--- a/substitute_holiday_test.go
+++ b/substitute_holiday_test.go
@@ -26,7 +26,7 @@ func TestSubstituteHolidayBefore(t *testing.T) {
 	}
 	year := 1968
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 }
 
 func TestSubstituteHolidayGoldenWeekSunday3(t *testing.T) {
@@ -51,14 +51,14 @@ func TestSubstituteHolidayGoldenWeekSunday3(t *testing.T) {
 	}
 	year := 2009
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 	substituteTestdata := []expectedSubstitute{
 		{
 			original: expected{5, 3, "憲法記念日", PublicHoliday},
 			holiday:  expected{5, 6, "振替休日", SubstituteHoliday},
 		},
 	}
-	checkSubstitute(t, year, dates, substituteTestdata)
+	testSubstitute(t, year, dates, substituteTestdata)
 }
 
 func TestSubstituteHolidayGoldenWeekSunday4(t *testing.T) {
@@ -83,7 +83,7 @@ func TestSubstituteHolidayGoldenWeekSunday4(t *testing.T) {
 	}
 	year := 2008
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 	substituteTestdata := []expectedSubstitute{
 		{
 			original: expected{5, 4, "みどりの日", PublicHoliday},
@@ -94,7 +94,7 @@ func TestSubstituteHolidayGoldenWeekSunday4(t *testing.T) {
 			holiday:  expected{11, 24, "振替休日", SubstituteHoliday},
 		},
 	}
-	checkSubstitute(t, year, dates, substituteTestdata)
+	testSubstitute(t, year, dates, substituteTestdata)
 }
 
 func TestSubstituteHolidayGoldenWeekSunday5(t *testing.T) {
@@ -119,7 +119,7 @@ func TestSubstituteHolidayGoldenWeekSunday5(t *testing.T) {
 	}
 	year := 2013
 	dates := InYear(year)
-	check(t, year, dates, testdata)
+	testHolidays(t, year, dates, testdata)
 	substituteTestdata := []expectedSubstitute{
 		{
 			original: expected{5, 5, "こどもの日", PublicHoliday},
@@ -130,18 +130,18 @@ func TestSubstituteHolidayGoldenWeekSunday5(t *testing.T) {
 			holiday:  expected{11, 4, "振替休日", SubstituteHoliday},
 		},
 	}
-	checkSubstitute(t, year, dates, substituteTestdata)
+	testSubstitute(t, year, dates, substituteTestdata)
 }
 
-func checkSubstitute(t *testing.T, year int, dates []Holiday, testdata []expectedSubstitute) {
+func testSubstitute(t *testing.T, year int, dates []Holiday, testdata []expectedSubstitute) {
 	t.Helper()
-	checkSubstituteNoOriginal(t, dates)
+	testSubstituteNoOriginal(t, dates)
 	for _, td := range testdata {
-		checkSubstituteInvalidOriginal(t, year, dates, td)
+		testSubstituteInvalidOriginal(t, year, dates, td)
 	}
 }
 
-func checkSubstituteNoOriginal(t *testing.T, dates []Holiday) {
+func testSubstituteNoOriginal(t *testing.T, dates []Holiday) {
 	for _, date := range dates {
 		if date.Kind() == SubstituteHoliday {
 			s := date.Time().Format("2006/1/2")
@@ -153,12 +153,12 @@ func checkSubstituteNoOriginal(t *testing.T, dates []Holiday) {
 	}
 }
 
-func checkSubstituteInvalidOriginal(t *testing.T, year int, dates []Holiday, td expectedSubstitute) {
+func testSubstituteInvalidOriginal(t *testing.T, year int, dates []Holiday, td expectedSubstitute) {
 	found := false
 	for _, date := range dates {
 		if date.Month() == td.holiday.month && date.Day() == td.holiday.day {
 			found = true
-			checkDate(t, year, date.Original(), td.original)
+			testDate(t, year, date.Original(), td.original)
 		}
 	}
 	if !found {

--- a/substitute_holiday_test.go
+++ b/substitute_holiday_test.go
@@ -56,8 +56,8 @@ func TestSubstituteHolidayGoldenWeekSunday3(t *testing.T) {
 	testHolidays(t, year, dates, testdata)
 	substituteTestdata := []expectedSubstitute{
 		{
-			original: expected{5, 3, "憲法記念日", flagday.PublicHoliday},
-			holiday:  expected{5, 6, "振替休日", flagday.SubstituteHoliday},
+			original: testdata[5], // 5/3
+			holiday:  testdata[8], // 5/6
 		},
 	}
 	testSubstitute(t, year, dates, substituteTestdata)
@@ -88,12 +88,12 @@ func TestSubstituteHolidayGoldenWeekSunday4(t *testing.T) {
 	testHolidays(t, year, dates, testdata)
 	substituteTestdata := []expectedSubstitute{
 		{
-			original: expected{5, 4, "みどりの日", flagday.PublicHoliday},
-			holiday:  expected{5, 6, "振替休日", flagday.SubstituteHoliday},
+			original: testdata[6], // 5/4
+			holiday:  testdata[8], // 5/6
 		},
 		{
-			original: expected{11, 23, "勤労感謝の日", flagday.PublicHoliday},
-			holiday:  expected{11, 24, "振替休日", flagday.SubstituteHoliday},
+			original: testdata[14], // 11/23
+			holiday:  testdata[15], // 11/24
 		},
 	}
 	testSubstitute(t, year, dates, substituteTestdata)
@@ -124,12 +124,12 @@ func TestSubstituteHolidayGoldenWeekSunday5(t *testing.T) {
 	testHolidays(t, year, dates, testdata)
 	substituteTestdata := []expectedSubstitute{
 		{
-			original: expected{5, 5, "こどもの日", flagday.PublicHoliday},
-			holiday:  expected{5, 6, "振替休日", flagday.SubstituteHoliday},
+			original: testdata[7], // 5/5
+			holiday:  testdata[8], // 5/6
 		},
 		{
-			original: expected{11, 3, "文化の日", flagday.PublicHoliday},
-			holiday:  expected{11, 4, "振替休日", flagday.SubstituteHoliday},
+			original: testdata[13], // 11/3
+			holiday:  testdata[14], // 11/4
 		},
 	}
 	testSubstitute(t, year, dates, substituteTestdata)

--- a/substitute_holiday_test.go
+++ b/substitute_holiday_test.go
@@ -147,10 +147,9 @@ func testSubstitute(t *testing.T, year int, dates []flagday.Holiday, testdata []
 func testSubstituteNoOriginal(t *testing.T, dates []flagday.Holiday) {
 	for _, date := range dates {
 		if date.Kind() == flagday.SubstituteHoliday {
-			s := date.Time().Format("2006/1/2")
 			if date.Original() == nil {
+				s := date.Time().Format("2006/1/2")
 				t.Errorf("Substitute holiday (%s) should have original holiday", s)
-				break
 			}
 		}
 	}

--- a/substitute_holiday_test.go
+++ b/substitute_holiday_test.go
@@ -138,6 +138,7 @@ func TestSubstituteHolidayGoldenWeekSunday5(t *testing.T) {
 func testSubstitute(t *testing.T, year int, dates []flagday.Holiday, testdata []expectedSubstitute) {
 	t.Helper()
 	testSubstituteNoOriginal(t, dates)
+	testSubstituteIsSubstituted(t, dates)
 	for _, td := range testdata {
 		testSubstituteInvalidOriginal(t, year, dates, td)
 	}
@@ -150,6 +151,17 @@ func testSubstituteNoOriginal(t *testing.T, dates []flagday.Holiday) {
 			if date.Original() == nil {
 				t.Errorf("Substitute holiday (%s) should have original holiday", s)
 				break
+			}
+		}
+	}
+}
+
+func testSubstituteIsSubstituted(t *testing.T, dates []flagday.Holiday) {
+	for _, date := range dates {
+		if date.Kind() == flagday.SubstituteHoliday {
+			if !date.Original().IsSubstituted() {
+				s := date.Original().Time().Format("2006/1/2")
+				t.Errorf("Substituted original holiday (%s) should have substituted flag", s)
 			}
 		}
 	}

--- a/substitute_holiday_test.go
+++ b/substitute_holiday_test.go
@@ -1,7 +1,9 @@
-package flagday
+package flagday_test
 
 import (
 	"testing"
+
+	"github.com/pinzolo/flagday"
 )
 
 type expectedSubstitute struct {
@@ -11,51 +13,51 @@ type expectedSubstitute struct {
 
 func TestSubstituteHolidayBefore(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 15, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 20, "春分の日", PublicHoliday},
-		{4, 29, "天皇誕生日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 5, "こどもの日", PublicHoliday}, // Sunday
-		{9, 15, "敬老の日", PublicHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 10, "体育の日", PublicHoliday},
-		{11, 03, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 15, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 20, "春分の日", flagday.PublicHoliday},
+		{4, 29, "天皇誕生日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday}, // Sunday
+		{9, 15, "敬老の日", flagday.PublicHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 10, "体育の日", flagday.PublicHoliday},
+		{11, 03, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
 	}
 	year := 1968
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 }
 
 func TestSubstituteHolidayGoldenWeekSunday3(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 12, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 20, "春分の日", PublicHoliday},
-		{4, 29, "昭和の日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday}, // Sunday
-		{5, 4, "みどりの日", PublicHoliday},
-		{5, 5, "こどもの日", PublicHoliday},
-		{5, 6, "振替休日", SubstituteHoliday},
-		{7, 20, "海の日", PublicHoliday},
-		{9, 21, "敬老の日", PublicHoliday},
-		{9, 22, "国民の休日", NationalHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 12, "体育の日", PublicHoliday},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
-		{12, 23, "天皇誕生日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 12, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 20, "春分の日", flagday.PublicHoliday},
+		{4, 29, "昭和の日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday}, // Sunday
+		{5, 4, "みどりの日", flagday.PublicHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{5, 6, "振替休日", flagday.SubstituteHoliday},
+		{7, 20, "海の日", flagday.PublicHoliday},
+		{9, 21, "敬老の日", flagday.PublicHoliday},
+		{9, 22, "国民の休日", flagday.NationalHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 12, "体育の日", flagday.PublicHoliday},
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
+		{12, 23, "天皇誕生日", flagday.PublicHoliday},
 	}
 	year := 2009
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 	substituteTestdata := []expectedSubstitute{
 		{
-			original: expected{5, 3, "憲法記念日", PublicHoliday},
-			holiday:  expected{5, 6, "振替休日", SubstituteHoliday},
+			original: expected{5, 3, "憲法記念日", flagday.PublicHoliday},
+			holiday:  expected{5, 6, "振替休日", flagday.SubstituteHoliday},
 		},
 	}
 	testSubstitute(t, year, dates, substituteTestdata)
@@ -63,35 +65,35 @@ func TestSubstituteHolidayGoldenWeekSunday3(t *testing.T) {
 
 func TestSubstituteHolidayGoldenWeekSunday4(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 14, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 20, "春分の日", PublicHoliday},
-		{4, 29, "昭和の日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "みどりの日", PublicHoliday}, // Sunday
-		{5, 5, "こどもの日", PublicHoliday},
-		{5, 6, "振替休日", SubstituteHoliday},
-		{7, 21, "海の日", PublicHoliday},
-		{9, 15, "敬老の日", PublicHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 13, "体育の日", PublicHoliday},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
-		{11, 24, "振替休日", SubstituteHoliday},
-		{12, 23, "天皇誕生日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 14, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 20, "春分の日", flagday.PublicHoliday},
+		{4, 29, "昭和の日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "みどりの日", flagday.PublicHoliday}, // Sunday
+		{5, 5, "こどもの日", flagday.PublicHoliday},
+		{5, 6, "振替休日", flagday.SubstituteHoliday},
+		{7, 21, "海の日", flagday.PublicHoliday},
+		{9, 15, "敬老の日", flagday.PublicHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 13, "体育の日", flagday.PublicHoliday},
+		{11, 3, "文化の日", flagday.PublicHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday}, // Sunday
+		{11, 24, "振替休日", flagday.SubstituteHoliday},
+		{12, 23, "天皇誕生日", flagday.PublicHoliday},
 	}
 	year := 2008
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 	substituteTestdata := []expectedSubstitute{
 		{
-			original: expected{5, 4, "みどりの日", PublicHoliday},
-			holiday:  expected{5, 6, "振替休日", SubstituteHoliday},
+			original: expected{5, 4, "みどりの日", flagday.PublicHoliday},
+			holiday:  expected{5, 6, "振替休日", flagday.SubstituteHoliday},
 		},
 		{
-			original: expected{11, 23, "勤労感謝の日", PublicHoliday},
-			holiday:  expected{11, 24, "振替休日", SubstituteHoliday},
+			original: expected{11, 23, "勤労感謝の日", flagday.PublicHoliday},
+			holiday:  expected{11, 24, "振替休日", flagday.SubstituteHoliday},
 		},
 	}
 	testSubstitute(t, year, dates, substituteTestdata)
@@ -99,41 +101,41 @@ func TestSubstituteHolidayGoldenWeekSunday4(t *testing.T) {
 
 func TestSubstituteHolidayGoldenWeekSunday5(t *testing.T) {
 	testdata := []expected{
-		{1, 1, "元日", PublicHoliday},
-		{1, 14, "成人の日", PublicHoliday},
-		{2, 11, "建国記念の日", PublicHoliday},
-		{3, 20, "春分の日", PublicHoliday},
-		{4, 29, "昭和の日", PublicHoliday},
-		{5, 3, "憲法記念日", PublicHoliday},
-		{5, 4, "みどりの日", PublicHoliday},
-		{5, 5, "こどもの日", PublicHoliday}, // Sunday
-		{5, 6, "振替休日", SubstituteHoliday},
-		{7, 15, "海の日", PublicHoliday},
-		{9, 16, "敬老の日", PublicHoliday},
-		{9, 23, "秋分の日", PublicHoliday},
-		{10, 14, "体育の日", PublicHoliday},
-		{11, 3, "文化の日", PublicHoliday},
-		{11, 4, "振替休日", SubstituteHoliday},
-		{11, 23, "勤労感謝の日", PublicHoliday},
-		{12, 23, "天皇誕生日", PublicHoliday},
+		{1, 1, "元日", flagday.PublicHoliday},
+		{1, 14, "成人の日", flagday.PublicHoliday},
+		{2, 11, "建国記念の日", flagday.PublicHoliday},
+		{3, 20, "春分の日", flagday.PublicHoliday},
+		{4, 29, "昭和の日", flagday.PublicHoliday},
+		{5, 3, "憲法記念日", flagday.PublicHoliday},
+		{5, 4, "みどりの日", flagday.PublicHoliday},
+		{5, 5, "こどもの日", flagday.PublicHoliday}, // Sunday
+		{5, 6, "振替休日", flagday.SubstituteHoliday},
+		{7, 15, "海の日", flagday.PublicHoliday},
+		{9, 16, "敬老の日", flagday.PublicHoliday},
+		{9, 23, "秋分の日", flagday.PublicHoliday},
+		{10, 14, "体育の日", flagday.PublicHoliday},
+		{11, 3, "文化の日", flagday.PublicHoliday}, // Sunday
+		{11, 4, "振替休日", flagday.SubstituteHoliday},
+		{11, 23, "勤労感謝の日", flagday.PublicHoliday},
+		{12, 23, "天皇誕生日", flagday.PublicHoliday},
 	}
 	year := 2013
-	dates := InYear(year)
+	dates := flagday.InYear(year)
 	testHolidays(t, year, dates, testdata)
 	substituteTestdata := []expectedSubstitute{
 		{
-			original: expected{5, 5, "こどもの日", PublicHoliday},
-			holiday:  expected{5, 6, "振替休日", SubstituteHoliday},
+			original: expected{5, 5, "こどもの日", flagday.PublicHoliday},
+			holiday:  expected{5, 6, "振替休日", flagday.SubstituteHoliday},
 		},
 		{
-			original: expected{11, 3, "文化の日", PublicHoliday},
-			holiday:  expected{11, 4, "振替休日", SubstituteHoliday},
+			original: expected{11, 3, "文化の日", flagday.PublicHoliday},
+			holiday:  expected{11, 4, "振替休日", flagday.SubstituteHoliday},
 		},
 	}
 	testSubstitute(t, year, dates, substituteTestdata)
 }
 
-func testSubstitute(t *testing.T, year int, dates []Holiday, testdata []expectedSubstitute) {
+func testSubstitute(t *testing.T, year int, dates []flagday.Holiday, testdata []expectedSubstitute) {
 	t.Helper()
 	testSubstituteNoOriginal(t, dates)
 	for _, td := range testdata {
@@ -141,9 +143,9 @@ func testSubstitute(t *testing.T, year int, dates []Holiday, testdata []expected
 	}
 }
 
-func testSubstituteNoOriginal(t *testing.T, dates []Holiday) {
+func testSubstituteNoOriginal(t *testing.T, dates []flagday.Holiday) {
 	for _, date := range dates {
-		if date.Kind() == SubstituteHoliday {
+		if date.Kind() == flagday.SubstituteHoliday {
 			s := date.Time().Format("2006/1/2")
 			if date.Original() == nil {
 				t.Errorf("Substitute holiday (%s) should have original holiday", s)
@@ -153,7 +155,7 @@ func testSubstituteNoOriginal(t *testing.T, dates []Holiday) {
 	}
 }
 
-func testSubstituteInvalidOriginal(t *testing.T, year int, dates []Holiday, td expectedSubstitute) {
+func testSubstituteInvalidOriginal(t *testing.T, year int, dates []flagday.Holiday, td expectedSubstitute) {
 	found := false
 	for _, date := range dates {
 		if date.Month() == td.holiday.month && date.Day() == td.holiday.day {


### PR DESCRIPTION
Add fields to `Holiday` interface that is related with substitute holiday.

### Original

If holiday is substitute holiday, `Original` method returns original holiday.

ex: 

```go
d, _ := flagday.PublicHolidayOf(2009, 5, 6)
fmt.Println(d.Kind() == flagday.SubstituteHoliday) // true
fmt.Println(d.Original().Time().Format("2006/1/2") // 2009/5/3
```

### IsSubstituted

If holiday is original holiday, `IsSubstituted` method returns `true`.

ex: 

```go
d, _ := flagday.PublicHolidayOf(2009, 5, 3)
fmt.Println(d.IsSubstituted()) // true
```
